### PR TITLE
Run tests via GitHub Actions on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test
-        run: set -o pipefail && swift test
+        run: set -o pipefail && swift test | xcbeautify --renderer github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
+      - '.spi.yml'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Test
+    runs-on: macOS-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test
+        run: set -o pipefail && swift test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Declarative Text Kit
 
-<!-- [![Build Status][build status badge]][build status] -->
+[![Build Status][build status badge]][build status]
 [![Platforms][platforms badge]][platforms]
 [![Documentation][documentation badge]][documentation]
 

--- a/Tests/DeclarativeTextKitTests/UseCaseTests.swift
+++ b/Tests/DeclarativeTextKitTests/UseCaseTests.swift
@@ -34,7 +34,7 @@ But it is nice.
         try buffer.insert("raw")  // Simulate typing at the selection
 
         assertBufferState(buffer, """
-# 
+# Heading
 
 ```raw{^}
 Text here. It is

--- a/Tests/DeclarativeTextKitTests/UseCaseTests.swift
+++ b/Tests/DeclarativeTextKitTests/UseCaseTests.swift
@@ -34,7 +34,7 @@ But it is nice.
         try buffer.insert("raw")  // Simulate typing at the selection
 
         assertBufferState(buffer, """
-# Heading
+# 
 
 ```raw{^}
 Text here. It is


### PR DESCRIPTION
[`xcbeautify`](https://swiftpackageindex.com/cpisciotta/xcbeautify) is already included in the runner image [`macOS-14`](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md).

Once other platforms are introduced, we could use a [matrix](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs) similar to [ChimeKit](https://github.com/ChimeHQ/ChimeKit/blob/main/.github/workflows/ci.yml).

If I am not mistaken, the GitHub Actions job will first be executed when this branch is merged into main.

Closes #3.