### PR TITLE
Refactored WordRange string iteration

### DIFF
--- a/Sources/DeclarativeTextKit/Buffer/Buffer.swift
+++ b/Sources/DeclarativeTextKit/Buffer/Buffer.swift
@@ -406,7 +406,7 @@ extension Buffer {
                 from: .whitespacesAndNewlines.inverted,
                 direction: .downstream,
                 in: searchRange.expanded(to: self.range, direction: .downstream)
-            ) ?? baseRange.endLocation
+            ) ?? baseRange.location
 
             searchRange = Buffer.Range(
                 startLocation: min(newStartLocation, searchRange.endLocation),  // If newStartLocation > endLocation, the whole searchRange is whitespace.

--- a/Sources/DeclarativeTextKit/Buffer/Buffer.swift
+++ b/Sources/DeclarativeTextKit/Buffer/Buffer.swift
@@ -258,6 +258,28 @@ extension NSRange {
             endLocation: endLocation
         )
     }
+
+    /// - Returns: Subrange that ends before `other`.
+    @inlinable
+    func prefix(upTo other: NSRange) -> NSRange {
+        precondition(self.location <= other.location && self.endLocation >= other.location, "Prefix requires range to reach up to or encompass other range")
+
+        return NSRange(
+            startLocation: self.location,
+            endLocation: other.location
+        )
+    }
+
+    /// - Returns: Subrange that starts after `other`.
+    @inlinable
+    func suffix(after other: NSRange) -> NSRange {
+        precondition(self.location <= other.endLocation && self.endLocation >= other.endLocation, "Suffix requires range to start right after or encompass other range")
+
+        return NSRange(
+            startLocation: other.endLocation,
+            endLocation: self.endLocation
+        )
+    }
 }
 
 extension Buffer {
@@ -297,11 +319,7 @@ extension Buffer {
             switch direction {
             case .upstream:
                 let matchedLocation = locationOfCharacter(
-                    in: Buffer.Range(
-                        location: self.range.location,
-                        // Account for start locations >0 (e.g. in ScopedBufferSlice) in length calculation
-                        length: searchRange.location - self.range.location
-                    ),
+                    in: self.range.prefix(upTo: searchRange),
                     direction: .upstream) {
                         isWordSeparator($0, wordBoundary: characterSet)
                     }
@@ -311,11 +329,7 @@ extension Buffer {
                 )
             case .downstream:
                 let matchedLocation = locationOfCharacter(
-                    in: Buffer.Range(
-                        location: searchRange.endLocation,
-                        // Account for start locations >0 (e.g. in ScopedBufferSlice) in length calculation
-                        length: self.range.endLocation - searchRange.endLocation
-                    ),
+                    in: self.range.suffix(after: searchRange),
                     direction: .downstream) {
                         isWordSeparator($0, wordBoundary: characterSet)
                     }

--- a/Sources/DeclarativeTextKit/Buffer/Buffer.swift
+++ b/Sources/DeclarativeTextKit/Buffer/Buffer.swift
@@ -235,53 +235,6 @@ let wordBoundary: CharacterSet = .whitespacesAndNewlines
     .union(.symbols)
     .union(.illegalCharacters)  // Not tested
 
-extension NSRange {
-    @inlinable
-    func expanded(
-        to other: NSRange,
-        direction: Direction
-    ) -> NSRange {
-        precondition(other.location <= self.location && other.endLocation >= self.endLocation, "Expansion requires other range to be larger")
-
-        let startLocation = switch direction {
-        case .upstream: other.location
-        case .downstream: self.location
-        }
-
-        let endLocation = switch direction {
-        case .upstream: self.endLocation
-        case .downstream: other.endLocation
-        }
-
-        return NSRange(
-            startLocation: startLocation,
-            endLocation: endLocation
-        )
-    }
-
-    /// - Returns: Subrange that ends before `other`.
-    @inlinable
-    func prefix(upTo other: NSRange) -> NSRange {
-        precondition(self.location <= other.location && self.endLocation >= other.location, "Prefix requires range to reach up to or encompass other range")
-
-        return NSRange(
-            startLocation: self.location,
-            endLocation: other.location
-        )
-    }
-
-    /// - Returns: Subrange that starts after `other`.
-    @inlinable
-    func suffix(after other: NSRange) -> NSRange {
-        precondition(self.location <= other.endLocation && self.endLocation >= other.endLocation, "Suffix requires range to start right after or encompass other range")
-
-        return NSRange(
-            startLocation: other.endLocation,
-            endLocation: self.endLocation
-        )
-    }
-}
-
 extension CharacterSet {
     @usableFromInline
     static let nonWhitespaceOrNewlines: CharacterSet = .whitespacesAndNewlines.inverted

--- a/Sources/DeclarativeTextKit/Buffer/Buffer.swift
+++ b/Sources/DeclarativeTextKit/Buffer/Buffer.swift
@@ -283,6 +283,11 @@ extension NSRange {
 }
 
 extension CharacterSet {
+    @usableFromInline
+    static let nonWhitespaceOrNewlines: CharacterSet = .whitespacesAndNewlines.inverted
+}
+
+extension CharacterSet {
     @inlinable
     func contains(characterSequence: NSString) -> Bool {
         return characterSequence.rangeOfCharacter(from: self) == NSRange(location: 0, length: characterSequence.length)
@@ -387,7 +392,7 @@ extension Buffer {
 
         // Trim trailing whitespace first, favoring upstream selection affinity, e.g. if `baseRange` is all whitespace.
         if let newEndLocation = nsContent.locationUpToCharacter(
-            from: .whitespacesAndNewlines.inverted,
+            from: .nonWhitespaceOrNewlines,
             direction: .upstream,
             in: searchRange.expanded(to: self.range, direction: .upstream))
         {
@@ -398,7 +403,7 @@ extension Buffer {
         }
         // Trim leading whitespace
         if let newStartLocation = nsContent.locationUpToCharacter(
-            from: .whitespacesAndNewlines.inverted,
+            from: .nonWhitespaceOrNewlines,
             direction: .downstream,
             in: searchRange.expanded(to: self.range, direction: .downstream)
            ) 
@@ -413,8 +418,8 @@ extension Buffer {
 
         // If the result is an empty range, characters adjacent to the location were all `wordBoundary` characters. Then we need to try again with relaxed conditions, skipping over whitespace first. Try forward search, then backward.
         if resultRange.length == 0 {
-            let downstreamNonWhitespaceLocation = locationOfCharacter(in: resultRange, direction: .downstream, includedIn: .whitespacesAndNewlines.inverted)
-            let upstreamNonWhitespaceLocation = locationOfCharacter(in: resultRange, direction: .upstream, includedIn: .whitespacesAndNewlines.inverted)
+            let downstreamNonWhitespaceLocation = locationOfCharacter(in: resultRange, direction: .downstream, includedIn: .nonWhitespaceOrNewlines)
+            let upstreamNonWhitespaceLocation = locationOfCharacter(in: resultRange, direction: .upstream, includedIn: .nonWhitespaceOrNewlines)
             // Prioritize look-behind over look-ahead *only* of the point is left-adjacent to non-whitespace character and the look-ahead is further away.
             if let upstreamNonWhitespaceLocation,
                let downstreamNonWhitespaceLocation,

--- a/Sources/DeclarativeTextKit/Buffer/Buffer.swift
+++ b/Sources/DeclarativeTextKit/Buffer/Buffer.swift
@@ -388,26 +388,23 @@ extension Buffer {
         var searchRange = baseRange
 
         // Trim trailing whitespace first, favoring upstream selection affinity, e.g. if `baseRange` is all whitespace.
-        if searchRange.length > 0 {
-            let newEndLocation = nsContent.locationUpToCharacter(
-                from: .whitespacesAndNewlines.inverted,
-                direction: .upstream,
-                in: searchRange.expanded(to: self.range, direction: .upstream)
-            ) ?? baseRange.endLocation
-
+        if let newEndLocation = nsContent.locationUpToCharacter(
+            from: .whitespacesAndNewlines.inverted,
+            direction: .upstream,
+            in: searchRange.expanded(to: self.range, direction: .upstream))
+        {
             searchRange = Buffer.Range(
                 startLocation: searchRange.location,
                 endLocation: max(newEndLocation, searchRange.location)  // If newEndLocation < location, the whole of searchRange is whitespace.
             )
         }
         // Trim leading whitespace
-        if searchRange.length > 0 {
-            let newStartLocation = nsContent.locationUpToCharacter(
-                from: .whitespacesAndNewlines.inverted,
-                direction: .downstream,
-                in: searchRange.expanded(to: self.range, direction: .downstream)
-            ) ?? baseRange.location
-
+        if let newStartLocation = nsContent.locationUpToCharacter(
+            from: .whitespacesAndNewlines.inverted,
+            direction: .downstream,
+            in: searchRange.expanded(to: self.range, direction: .downstream)
+           ) 
+        {
             searchRange = Buffer.Range(
                 startLocation: min(newStartLocation, searchRange.endLocation),  // If newStartLocation > endLocation, the whole searchRange is whitespace.
                 endLocation: searchRange.endLocation

--- a/Sources/DeclarativeTextKit/Buffer/Buffer.swift
+++ b/Sources/DeclarativeTextKit/Buffer/Buffer.swift
@@ -235,6 +235,31 @@ let wordBoundary: CharacterSet = .whitespacesAndNewlines
     .union(.symbols)
     .union(.illegalCharacters)  // Not tested
 
+extension NSRange {
+    @inlinable
+    func expanded(
+        to other: NSRange,
+        direction: Direction
+    ) -> NSRange {
+        precondition(other.location <= self.location && other.endLocation >= self.endLocation, "Expansion requires other range to be larger")
+
+        let startLocation = switch direction {
+        case .upstream: other.location
+        case .downstream: self.location
+        }
+
+        let endLocation = switch direction {
+        case .upstream: self.endLocation
+        case .downstream: other.endLocation
+        }
+
+        return NSRange(
+            startLocation: startLocation,
+            endLocation: endLocation
+        )
+    }
+}
+
 extension Buffer {
     @inlinable
     public func wordRange(
@@ -337,10 +362,7 @@ extension Buffer {
             let newEndLocation = nsContent.locationUpToCharacter(
                 from: .whitespacesAndNewlines.inverted,
                 direction: .upstream,
-                in: Buffer.Range(
-                    startLocation: self.range.location,
-                    endLocation: searchRange.endLocation
-                )
+                in: searchRange.expanded(to: self.range, direction: .upstream)
             ) ?? baseRange.endLocation
 
             searchRange = Buffer.Range(
@@ -353,10 +375,7 @@ extension Buffer {
             let newStartLocation = nsContent.locationUpToCharacter(
                 from: .whitespacesAndNewlines.inverted,
                 direction: .downstream,
-                in: Buffer.Range(
-                    startLocation: searchRange.location,
-                    endLocation: self.range.endLocation
-                )
+                in: searchRange.expanded(to: self.range, direction: .downstream)
             ) ?? baseRange.endLocation
 
             searchRange = Buffer.Range(

--- a/Sources/DeclarativeTextKit/Buffer/NSMutableString+BufferCompatibility.swift
+++ b/Sources/DeclarativeTextKit/Buffer/NSMutableString+BufferCompatibility.swift
@@ -5,7 +5,7 @@ import Foundation
 extension NSMutableString {
     @usableFromInline
     func unsafeCharacter(at location: Buffer.Location) -> Buffer.Content {
-        return unsafeContent(in: self.rangeOfComposedCharacterSequences(for: .init(location: location, length: 1)))
+        return unsafeContent(in: self.rangeOfComposedCharacterSequence(at: location))
     }
 
     @usableFromInline

--- a/Sources/DeclarativeTextKit/Buffer/UTF16.swift
+++ b/Sources/DeclarativeTextKit/Buffer/UTF16.swift
@@ -16,6 +16,15 @@ extension UTF16Range {
             length = newValue - location
         }
     }
+
+    @inlinable @inline(__always)
+    init(
+        startLocation: UTF16Offset,
+        endLocation: UTF16Offset
+    ) {
+        precondition(startLocation <= endLocation)
+        self.init(location: startLocation, length: endLocation - startLocation)
+    }
 }
 
 public func length(of string: NSString) -> UTF16Length {

--- a/Sources/DeclarativeTextKit/NSRange+expandedToOther.swift
+++ b/Sources/DeclarativeTextKit/NSRange+expandedToOther.swift
@@ -1,0 +1,28 @@
+//  Copyright © 2024 Christian Tietze. All rights reserved. Distributed under the MIT License.
+
+import Foundation
+
+extension NSRange {
+    @inlinable
+    func expanded(
+        to other: NSRange,
+        direction: Direction
+    ) -> NSRange {
+        precondition(other.location <= self.location && other.endLocation >= self.endLocation, "Expansion requires other range to be larger")
+
+        let startLocation = switch direction {
+        case .upstream: other.location
+        case .downstream: self.location
+        }
+
+        let endLocation = switch direction {
+        case .upstream: self.endLocation
+        case .downstream: other.endLocation
+        }
+
+        return NSRange(
+            startLocation: startLocation,
+            endLocation: endLocation
+        )
+    }
+}

--- a/Sources/DeclarativeTextKit/NSRange+prefix.swift
+++ b/Sources/DeclarativeTextKit/NSRange+prefix.swift
@@ -1,0 +1,16 @@
+//  Copyright © 2024 Christian Tietze. All rights reserved. Distributed under the MIT License.
+
+import Foundation
+
+extension NSRange {
+    /// - Returns: Subrange that ends before `other`.
+    @inlinable
+    func prefix(upTo other: NSRange) -> NSRange {
+        precondition(self.location <= other.location && self.endLocation >= other.location, "Prefix requires range to reach up to or encompass other range")
+
+        return NSRange(
+            startLocation: self.location,
+            endLocation: other.location
+        )
+    }
+}

--- a/Sources/DeclarativeTextKit/NSRange+prefix.swift
+++ b/Sources/DeclarativeTextKit/NSRange+prefix.swift
@@ -6,11 +6,17 @@ extension NSRange {
     /// - Returns: Subrange that ends before `other`.
     @inlinable
     func prefix(upTo other: NSRange) -> NSRange {
-        precondition(self.location <= other.location && self.endLocation >= other.location, "Prefix requires range to reach up to or encompass other range")
+        return prefix(upTo: other.location)
+    }
+
+    /// - Returns: Subrange that ends before `location`.
+    @inlinable
+    func prefix(upTo location: Int) -> NSRange {
+        precondition(self.location <= location && self.endLocation >= location, "Prefix requires range to reach up to or encompass location")
 
         return NSRange(
             startLocation: self.location,
-            endLocation: other.location
+            endLocation: location
         )
     }
 }

--- a/Sources/DeclarativeTextKit/NSRange+suffix.swift
+++ b/Sources/DeclarativeTextKit/NSRange+suffix.swift
@@ -6,10 +6,16 @@ extension NSRange {
     /// - Returns: Subrange that starts after `other`.
     @inlinable
     func suffix(after other: NSRange) -> NSRange {
-        precondition(self.location <= other.endLocation && self.endLocation >= other.endLocation, "Suffix requires range to start right after or encompass other range")
+        return suffix(after: other.endLocation)
+    }
+
+    /// - Returns: Subrange that starts after `location`.
+    @inlinable
+    func suffix(after location: Int) -> NSRange {
+        precondition(self.location <= location && self.endLocation >= location, "Suffix requires range to start right after or encompass location")
 
         return NSRange(
-            startLocation: other.endLocation,
+            startLocation: location,
             endLocation: self.endLocation
         )
     }

--- a/Sources/DeclarativeTextKit/NSRange+suffix.swift
+++ b/Sources/DeclarativeTextKit/NSRange+suffix.swift
@@ -1,0 +1,16 @@
+//  Copyright © 2024 Christian Tietze. All rights reserved. Distributed under the MIT License.
+
+import Foundation
+
+extension NSRange {
+    /// - Returns: Subrange that starts after `other`.
+    @inlinable
+    func suffix(after other: NSRange) -> NSRange {
+        precondition(self.location <= other.endLocation && self.endLocation >= other.endLocation, "Suffix requires range to start right after or encompass other range")
+
+        return NSRange(
+            startLocation: other.endLocation,
+            endLocation: self.endLocation
+        )
+    }
+}

--- a/Sources/DeclarativeTextKit/NSString+locationUpToCharacter.swift
+++ b/Sources/DeclarativeTextKit/NSString+locationUpToCharacter.swift
@@ -2,7 +2,8 @@
 
 import Foundation
 
-public enum Direction {
+@usableFromInline
+enum Direction {
     /// Left-to-right or towards-the-end search in a string.
     case downstream
     /// Right-to-left or towards-the-beginning search in a string.

--- a/Sources/DeclarativeTextKit/NSString+locationUpToCharacter.swift
+++ b/Sources/DeclarativeTextKit/NSString+locationUpToCharacter.swift
@@ -1,0 +1,45 @@
+//  Copyright © 2024 Christian Tietze. All rights reserved. Distributed under the MIT License.
+
+import Foundation
+
+public enum Direction {
+    /// Left-to-right or towards-the-end search in a string.
+    case downstream
+    /// Right-to-left or towards-the-beginning search in a string.
+    case upstream
+}
+
+extension NSString {
+    /// Finds and returns the location adjacent to the first character from `characterSet` found in the substring `range` in `direction`.
+    ///
+    /// Use this to find an insertion point _next to_ a match to insert text into.
+    ///
+    /// ## Example of 'adjacency'
+    ///
+    /// To finding location _up to_ a character from `CharacterSet.punctuationCharacters` in this piece of text:
+    ///
+    ///     "a (test) text"
+    ///
+    /// will be one of the following, with the location denoted by `ˇ`:
+    ///
+    ///     "a ˇ(test) text"  // Downstream / from left to right
+    ///     "a (test)ˇ text"  // Upstream / from right to left
+    @inlinable
+    public func locationUpToCharacter(
+        from characterSet: CharacterSet,
+        direction: Direction,
+        in range: NSRange
+    ) -> Buffer.Location? {
+        var options: NSString.CompareOptions = [.anchored]
+        if direction == .upstream { options.insert(.backwards) }
+
+        let result = rangeOfCharacter(from: characterSet, options: options, range: range)
+
+        if result == .notFound { return nil }
+
+        return switch direction {
+        case .upstream: result.endLocation
+        case .downstream: result.location
+        }
+    }
+}

--- a/Sources/DeclarativeTextKit/NSString+locationUpToCharacter.swift
+++ b/Sources/DeclarativeTextKit/NSString+locationUpToCharacter.swift
@@ -30,6 +30,8 @@ extension NSString {
         direction: Direction,
         in range: NSRange
     ) -> Buffer.Location? {
+        guard range.length > 0 else { return nil }
+
         var options: NSString.CompareOptions = []
         if direction == .upstream { options.insert(.backwards) }
 

--- a/Sources/DeclarativeTextKit/NSString+locationUpToCharacter.swift
+++ b/Sources/DeclarativeTextKit/NSString+locationUpToCharacter.swift
@@ -30,7 +30,7 @@ extension NSString {
         direction: Direction,
         in range: NSRange
     ) -> Buffer.Location? {
-        var options: NSString.CompareOptions = [.anchored]
+        var options: NSString.CompareOptions = []
         if direction == .upstream { options.insert(.backwards) }
 
         let result = rangeOfCharacter(from: characterSet, options: options, range: range)


### PR DESCRIPTION
The word range lookup used `NSString` enumeration was a bit awkward to use. Its procedural nature to 'stop' and set captured variables outside of its context made it hard to follow.

During this refactoring, it turned out that, nlike `NSString.rangeOfCharacter(...)`, `enumerateSubstrings` correctly handles Emoji. So it comes with a lot for free.

I couldn't get `rangeOfCharacter` for `CharacterSet.whitespacesAndNewlines.inverted` to *not* halt at Emoji. (Could be because some Emoji use 'joiners' which are detected as whitespace because the `rangeOfCharacter` method doesn't respect composed character sequences?)

I could get a custom character iterator to work, though.